### PR TITLE
DO-86 Cleanup build cycle

### DIFF
--- a/system/classes/Kohana/Core.php
+++ b/system/classes/Kohana/Core.php
@@ -204,11 +204,11 @@ class Kohana_Core {
 
 		/**
 		 * Enable xdebug parameter collection in development mode to improve fatal stack traces.
-		 */
+		 * Kaboodle customisation. No longer required due to Xdebug upgrade.
 		if (Kohana::$environment == Kohana::DEVELOPMENT AND extension_loaded('xdebug'))
 		{
 		    ini_set('xdebug.collect_params', 3);
-		}
+		} */
 
 		// Enable the Kohana shutdown handler, which catches E_FATAL errors.
 		register_shutdown_function(['Kohana', 'shutdown_handler']);

--- a/system/classes/Kohana/Request/Client/Internal.php
+++ b/system/classes/Kohana/Request/Client/Internal.php
@@ -112,8 +112,8 @@ class Kohana_Request_Client_Internal extends Request_Client {
 		}
 		catch (Exception $e)
 		{
-			// Generate an appropriate Response object
-			$response = Kohana_Exception::_handler($e);
+			// Kaboodle customisation
+			throw $e;
 		}
 
 		// Restore the previous request

--- a/system/classes/Kohana/Request/Client/Internal.php
+++ b/system/classes/Kohana/Request/Client/Internal.php
@@ -110,11 +110,7 @@ class Kohana_Request_Client_Internal extends Request_Client {
 			// Get the response via the Exception
 			$response = $e->get_response();
 		}
-		catch (Exception $e)
-		{
-			// Kaboodle customisation
-			throw $e;
-		}
+		// Kaboodle customisation (remove final catch)
 
 		// Restore the previous request
 		Request::$current = $previous;


### PR DESCRIPTION
### Changed
- Migrating Pacman build patches into this **fork** of `koseven` to simplify build cycle
  - Sourced from https://github.com/kaboodle-solutions/pacman/blob/develop/fix_kohana_exceptions.diff
- Reduce log noise for xdebug (on EVERY request)

## Notes

See https://github.com/kaboodle-solutions/pacman/pull/3557 for details on resulting cleanup in Pacman
